### PR TITLE
Hiyokoクラスの更新（持ちゴマエリアからの直接昇格禁止機能）

### DIFF
--- a/Hiyoko.pde
+++ b/Hiyoko.pde
@@ -14,9 +14,9 @@ class Hiyoko extends AbstractKoma {
   }
   
   void updatePos(int toX, int toY) {
-    if(this.team==0 && toX==board.bArea.posX+board.bArea.yoko-1){
+    if(this.team==0 && toX==board.bArea.posX+board.bArea.yoko-1 && !this.kStat.captured){
       komaList.promote(this,toX,toY);
-    }else if(this.team==1 && toX==board.bArea.posX){
+    }else if(this.team==1 && toX==board.bArea.posX && !this.kStat.captured){
       komaList.promote(this,toX,toY);
     }
     super.updatePos(toX,toY);


### PR DESCRIPTION
HiyokoクラスのupdatePos()メソッドを修正し，持ちゴマエリアにあるHiyokoを相手陣地に直接置いても昇格しないようにする updatePos()メソッドにおいて，Hiyokoのチームをif文で確認する際に，kStat.capturedの値がtrueでないかを確認する処理を追加